### PR TITLE
GEN-5: Test: Implement dark mode toggle

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,44 @@
+Here is a detailed technical implementation plan for the dark mode toggle feature.
+
+### 1. Objective
+To implement a user-facing dark mode toggle within the settings page that allows users to seamlessly switch between light and dark themes. The selected preference must be persisted across browser sessions using `localStorage`, ensuring a consistent user experience.
+
+### 2. Proposed Changes
+
+**A. UI Implementation (Settings Page)**
+*   **Component Creation:** Integrate a UI toggle component (e.g., a Switch or a styled Checkbox) into the Settings page layout.
+*   **Labeling:** Add clear typography indicating "Theme" or "Dark Mode" alongside the toggle. 
+
+**B. State Management & Logic**
+*   **Theme Provider/Context:** Implement a global state manager (e.g., a `ThemeProvider` Context in React) to wrap the application and expose the current theme state (`light` or `dark`) and a `toggleTheme` function.
+*   **DOM Manipulation:** Update the global state logic to append or remove a `dark` CSS class (or a `data-theme="dark"` attribute) on the root `<html>` or `<body>` element when the state changes.
+
+**C. Persistence (localStorage)**
+*   **Initialization Logic:** On application load, evaluate the initial theme in the following order of precedence:
+    1. Check `localStorage` for a saved user preference (e.g., `localStorage.getItem('theme-preference')`).
+    2. If no value exists in `localStorage`, check the OS-level system preference using `window.matchMedia('(prefers-color-scheme: dark)').matches`.
+    3. Fall back to a default theme (typically `light`).
+*   **Update Logic:** When the user clicks the toggle, update the global state, update the DOM class, and execute `localStorage.setItem('theme-preference', newTheme)`.
+
+### 3. Technical Considerations
+
+*   **Flash of Unstyled Content (FOUC):** To prevent the screen from flashing white on initial load for users with a saved dark mode preference, inject a small, blocking inline `<script>` in the `<head>` of the `index.html`. This script should read `localStorage` and apply the correct DOM class before the main JavaScript bundle parses and executes.
+*   **Accessibility (a11y):** Ensure the toggle component uses the correct ARIA attributes. It should have `role="switch"`, an `aria-checked` attribute reflecting the current state, and a clear `aria-label` (e.g., "Toggle dark mode"). keyboard navigability (Enter/Space to toggle) must be supported.
+*   **Cross-Tab Synchronization:** Implement an event listener for the `storage` event. If a user has multiple tabs of the application open and changes the theme in one tab's settings, the other tabs should detect the `localStorage` change and update their theme dynamically without requiring a page refresh.
+*   **CSS Architecture:** Ensure the existing styling system (e.g., CSS Variables, Tailwind CSS, or Styled Components) is correctly configured to respond to the root-level class/attribute change.
+
+### 4. Testing Strategy
+
+*   **Unit Testing:**
+    *   Verify the toggle component renders correctly with both `true` and `false` states.
+    *   Test utility functions responsible for reading from and writing to `localStorage`.
+*   **Integration Testing:**
+    *   Mount the Settings page within the `ThemeProvider` and simulate a click on the toggle. Verify that the context state updates appropriately.
+    *   Mock `window.matchMedia` to ensure the system preference fallback logic behaves correctly when `localStorage` is empty.
+*   **End-to-End (E2E) Testing (e.g., Cypress or Playwright):**
+    *   Navigate to the settings page, click the dark mode toggle, and verify that the `dark` class is attached to the root HTML element.
+    *   Reload the page and verify that the `dark` class remains attached (validating `localStorage` persistence).
+*   **Manual QA:**
+    *   Test on multiple browsers (Chrome, Safari, Firefox).
+    *   Verify no FOUC occurs on a hard refresh.
+    *   Use a screen reader (e.g., VoiceOver or NVDA) to ensure the toggle state is clearly announced.


### PR DESCRIPTION
## Implementation Plan for GEN-5

[Notion Plan](https://www.notion.so/GEN-5-Test-Implement-dark-mode-toggle-324112d50fe68192add2e4062cc13787)

### Summary
Here is a detailed technical implementation plan for the dark mode toggle feature.

### 1. Objective
To implement a user-facing dark mode toggle within the settings page that allows users to seamlessly switch between light and dark themes. The selected preference must be persisted across browser sessions using `localStorage`, ensuring a consistent user experience.

### 2. Proposed Changes

**A. UI Implementation (Settings Page)**
*   **Component Creation:** Integrate a UI toggle component (e.g., a Switch or a styled Checkbox) into the Settings page layout.
*   **Labeling:** Add clear typography indicating "Theme" or "Dark Mode" alongside the toggle. 

**B. State Management & Logic**
*   **Theme Provider/Context:** Implement a global state manager (e.g., a `ThemeProvider` Context in React) to wrap the application and expose the current theme state (`light` or `dark`) and a `toggleTheme` function.
*   **DOM Manipulation:** Update the global state logic to append or remove a `dark` CSS cl...